### PR TITLE
Quick doc update for spoofing hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,13 @@ s.send g[1], 0
 
 ```
 
-## Spoofing Hostname in gmetrics ##
+## Spoofing a hostname in gmetrics ##
+
 To spoof a hostname with the gmetric library you will need to add the following keys to your gmetric.
 This works with both GMetric.send() and GMetric.pack().
  
 * spoof - takes a value of 1 or True
-* hostname - expects a value of <ip>:<hostname>.
+* hostname - expects a value of ip_address:hostname.
 
 
 ### License

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Ganglia::GMetric.send("127.0.0.1", 8670, {
   :dmax => 300,
   :group => 'test'
 })
-```
 
 ## Example: Generating the Meta and Metric packets
 
@@ -38,7 +37,16 @@ s = UDPSocket.new
 s.connect("127.0.0.1", 8670)
 s.send g[0], 0
 s.send g[1], 0
+
 ```
+
+## Spoofing Hostname in gmetrics ##
+To spoof a hostname with the gmetric library you will need to add the following keys to your gmetric.
+This works with both GMetric.send() and GMetric.pack().
+ 
+* spoof - takes a value of 1 or True
+* hostname - expects a value of <ip>:<hostname>.
+
 
 ### License
 


### PR DESCRIPTION
It's not clear from the documentation how to spoof a hostname, or what format the :hostname value should be in. I found out via trial and error (read netcat and gmond logs) that its not override_hostname [1] that is being set, but rather spoof, which expects the field to be specified in the format  IP_ADDRESS:HOSTNAME

Since GMetric will not validate the format of the hostname key as being in the expected format, setting just hostname results in the gmond recipient  dropping your metrics on the floor for having an invalid spoof hostname.
